### PR TITLE
[#9] Add Map & Reduce implementation for List

### DIFF
--- a/collections/list.go
+++ b/collections/list.go
@@ -106,8 +106,8 @@ func (l *List[T]) IndexOf(item T) int {
 
 // Use Map with a callback function to transform given list to a different one.
 // Map has a return type od ListTransformation and the returned value should be passed to the CopyFrom method to generate the required list.
-func (l *List[T]) Map(callback listMapFunction) ListTransformation {
-	result := make([]interface{}, l.Size())
+func (l *List[T]) Map(callback listMapFunction[T]) ListTransformation {
+	result := make([]any, l.Size())
 	for i, e := range l.items {
 		result[i] = callback(e, i)
 	}
@@ -198,11 +198,11 @@ func (_ List[T]) Type() CollectionType {
 
 // Temporary value store that stores results of Map method.
 type ListTransformation struct {
-	values []interface{}
+	values []any
 }
 
 // Type of callback function that needs to be passed to Map method.
-type listMapFunction func(T any, index int) interface{}
+type listMapFunction[T CollectionElement] func(element T, index int) any
 
 // Type of callback function that needs to be passed to Reduce method.
 type listReduceFunction[T CollectionElement] func(result T, item T) T

--- a/collections/list.go
+++ b/collections/list.go
@@ -36,6 +36,21 @@ func (l *List[T]) Contains(item T) bool {
 	return l.IndexOf(item) != -1
 }
 
+// Copies elements to the given List from ListTransformation that is returned by Map method.
+// Returns error if the value present in the transformation is not the same type as the List element type T.
+func (l *List[T]) CopyFrom(lt ListTransformation) error {
+	for _, e := range lt.values {
+		v, ok := e.(T)
+		if !ok {
+			return errors.New(
+				"Type assertion failed. The given transformation contains values that cannot be stored in the list",
+			)
+		}
+		l.Add(v)
+	}
+	return nil
+}
+
 // Returns number of occurences of given element in the list.
 func (l *List[T]) CountOf(item T) (count int) {
 	for _, e := range l.items {
@@ -87,6 +102,25 @@ func (l *List[T]) IndexOf(item T) int {
 		}
 	}
 	return -1
+}
+
+// Use Map with a callback function to transform given list to a different one.
+// Map has a return type od ListTransformation and the returned value should be passed to the CopyFrom method to generate the required list.
+func (l *List[T]) Map(callback listMapFunction) ListTransformation {
+	result := make([]interface{}, l.Size())
+	for i, e := range l.items {
+		result[i] = callback(e, i)
+	}
+	return ListTransformation{values: result}
+}
+
+// Use Reduce to reduce the given list elements to a single element of same type T based on a callback function.
+func (l *List[T]) Reduce(callback listReduceFunction[T], initialValue T) T {
+	result := initialValue
+	for _, e := range l.items {
+		result = callback(result, e)
+	}
+	return result
 }
 
 // Removes all occurences of the given element from the list.
@@ -161,3 +195,14 @@ func (l List[T]) String() string {
 func (_ List[T]) Type() CollectionType {
 	return TypeList
 }
+
+// Temporary value store that stores results of Map method.
+type ListTransformation struct {
+	values []interface{}
+}
+
+// Type of callback function that needs to be passed to Map method.
+type listMapFunction func(T any, index int) interface{}
+
+// Type of callback function that needs to be passed to Reduce method.
+type listReduceFunction[T CollectionElement] func(result T, item T) T

--- a/collections/list_test.go
+++ b/collections/list_test.go
@@ -363,7 +363,7 @@ func TestListType(t *testing.T) {
 	assert.Equal(t, collections.TypeList, l.Type())
 }
 
-func TestListMapValidScenario(t *testing.T) {
+func TestListMap(t *testing.T) {
 	studentMarks := []struct {
 		name  string
 		marks int
@@ -374,55 +374,20 @@ func TestListMapValidScenario(t *testing.T) {
 		{name: "Peter", marks: 50},
 	}
 
-	l := collections.NewListFromArray(studentMarks)
-
-	getMarksCallbackFunc := func(elem struct {
-		name  string
-		marks int
-	}, index int) any {
-		return elem.marks
-	}
-
-	lt := l.Map(getMarksCallbackFunc)
-
-	nl := collections.NewEmptyList[int](l.Size())
-	error := nl.CopyFrom(lt)
-
-	assert.Nil(t, error)
-}
-
-func TestListMapInvalidScenarioReturnsErrorWhenThereIsTypeMismatch(t *testing.T) {
-	studentMarks := []struct {
-		name  string
-		marks int
-	}{
-		{name: "Jack", marks: 100},
-		{name: "Jill", marks: 90},
-		{name: "Tom", marks: 75},
-		{name: "Peter", marks: 50},
-	}
+	expected := collections.NewListFromArray([]int{100, 90, 75, 50})
 
 	l := collections.NewListFromArray(studentMarks)
 
 	getMarksCallbackFunc := func(elem struct {
 		name  string
 		marks int
-	}, index int) any {
+	}, index int) int {
 		return elem.marks
 	}
 
-	lt := l.Map(getMarksCallbackFunc)
+	nl := collections.Map(l, getMarksCallbackFunc)
 
-	nl := collections.NewEmptyList[string](l.Size())
-	error := nl.CopyFrom(lt)
-
-	assert.Equal(
-		t,
-		error,
-		errors.New(
-			"Type assertion failed. The given transformation contains values that cannot be stored in the list",
-		),
-	)
+	assert.Equal(t, expected, nl)
 }
 
 func TestListReduce(t *testing.T) {
@@ -453,7 +418,7 @@ func TestListReduce(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		output := tc.inputList.Reduce(tc.callbackFunc, tc.initialValue)
+		output := collections.Reduce(tc.inputList, tc.callbackFunc, tc.initialValue)
 		assert.Equal(t, tc.output, output)
 	}
 }

--- a/collections/list_test.go
+++ b/collections/list_test.go
@@ -362,3 +362,98 @@ func TestListType(t *testing.T) {
 
 	assert.Equal(t, collections.TypeList, l.Type())
 }
+
+func TestListMapValidScenario(t *testing.T) {
+	studentMarks := []struct {
+		name  string
+		marks int
+	}{
+		{name: "Jack", marks: 100},
+		{name: "Jill", marks: 90},
+		{name: "Tom", marks: 75},
+		{name: "Peter", marks: 50},
+	}
+
+	l := collections.NewListFromArray(studentMarks)
+
+	getMarksCallbackFunc := func(elem interface{}, index int) interface{} {
+		return elem.(struct {
+			name  string
+			marks int
+		}).marks
+	}
+
+	lt := l.Map(getMarksCallbackFunc)
+
+	nl := collections.NewEmptyList[int](l.Size())
+	error := nl.CopyFrom(lt)
+
+	assert.Nil(t, error)
+}
+
+func TestListMapInvalidScenarioReturnsErrorWhenThereIsTypeMismatch(t *testing.T) {
+	studentMarks := []struct {
+		name  string
+		marks int
+	}{
+		{name: "Jack", marks: 100},
+		{name: "Jill", marks: 90},
+		{name: "Tom", marks: 75},
+		{name: "Peter", marks: 50},
+	}
+
+	l := collections.NewListFromArray(studentMarks)
+
+	getMarksCallbackFunc := func(elem interface{}, index int) interface{} {
+		return elem.(struct {
+			name  string
+			marks int
+		}).marks
+	}
+
+	lt := l.Map(getMarksCallbackFunc)
+
+	nl := collections.NewEmptyList[string](l.Size())
+	error := nl.CopyFrom(lt)
+
+	assert.Equal(
+		t,
+		error,
+		errors.New(
+			"Type assertion failed. The given transformation contains values that cannot be stored in the list",
+		),
+	)
+}
+
+func TestListReduce(t *testing.T) {
+	testCases := []struct {
+		inputList    *collections.List[int]
+		callbackFunc func(result int, current int) int
+		initialValue int
+		output       int
+	}{
+		{
+			inputList:    collections.NewListFromArray([]int{1, 2, 3, 4, 5}),
+			callbackFunc: func(result int, current int) int { return result + current },
+			initialValue: 0,
+			output:       15,
+		},
+		{
+			inputList:    collections.NewListFromArray([]int{1, 2, 3, 4, 5}),
+			callbackFunc: func(result int, current int) int { return result * current },
+			initialValue: 1,
+			output:       120,
+		},
+		{
+			inputList:    collections.NewListFromArray([]int{1, 2, 3, 4, 5}),
+			callbackFunc: func(result int, current int) int { return result + (current * current) },
+			initialValue: 0,
+			output:       55,
+		},
+	}
+
+	for _, tc := range testCases {
+		output := tc.inputList.Reduce(tc.callbackFunc, tc.initialValue)
+		assert.Equal(t, tc.output, output)
+	}
+}

--- a/collections/list_test.go
+++ b/collections/list_test.go
@@ -376,11 +376,11 @@ func TestListMapValidScenario(t *testing.T) {
 
 	l := collections.NewListFromArray(studentMarks)
 
-	getMarksCallbackFunc := func(elem interface{}, index int) interface{} {
-		return elem.(struct {
-			name  string
-			marks int
-		}).marks
+	getMarksCallbackFunc := func(elem struct {
+		name  string
+		marks int
+	}, index int) any {
+		return elem.marks
 	}
 
 	lt := l.Map(getMarksCallbackFunc)
@@ -404,11 +404,11 @@ func TestListMapInvalidScenarioReturnsErrorWhenThereIsTypeMismatch(t *testing.T)
 
 	l := collections.NewListFromArray(studentMarks)
 
-	getMarksCallbackFunc := func(elem interface{}, index int) interface{} {
-		return elem.(struct {
-			name  string
-			marks int
-		}).marks
+	getMarksCallbackFunc := func(elem struct {
+		name  string
+		marks int
+	}, index int) any {
+		return elem.marks
 	}
 
 	lt := l.Map(getMarksCallbackFunc)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module linq
 
-go 1.18
+go 1.20
 
 require github.com/stretchr/testify v1.8.2
 


### PR DESCRIPTION
Issue #9 

Changes:
- Adds support for Aggregate functions for structs using Map in List.
- Adds Reduce method in List.