### PR TITLE
Implement set operations: Union, Intersection, Difference

### DIFF
--- a/set.go
+++ b/set.go
@@ -45,6 +45,19 @@ func (s *Set[T]) Extend(s2 *Set[T]) {
 	}
 }
 
+// Returns a new set instance as the Union of both sets.
+// This is the same as Extend, but without updating the rhs set.
+func (s *Set[T]) Union(s2 *Set[T]) *Set[T] {
+	union := NewSet[T]()
+	for key := range s.items {
+		union.Add(key)
+	}
+	for key := range s2.items {
+		union.Add(key)
+	}
+	return union
+}
+
 // Removes all elements from the set.
 func (s *Set[T]) Clear() {
 	s.items = make(map[T]struct{})

--- a/set.go
+++ b/set.go
@@ -58,6 +58,26 @@ func (s *Set[T]) Union(s2 *Set[T]) *Set[T] {
 	return union
 }
 
+// Returns a new set instance containing the elements that exists in both sets.
+func (s *Set[T]) Intersection(s2 *Set[T]) *Set[T] {
+	intersection := NewSet[T]()
+	if s.Size() < s2.Size() { // This ensures it will run through the smallest number of keys
+		for key := range s.items {
+			if s2.Contains(key) {
+				intersection.Add(key)
+			}
+		}
+		return intersection
+	}
+
+	for key := range s2.items {
+		if s.Contains(key) {
+			intersection.Add(key)
+		}
+	}
+	return intersection
+}
+
 // Removes all elements from the set.
 func (s *Set[T]) Clear() {
 	s.items = make(map[T]struct{})

--- a/set.go
+++ b/set.go
@@ -78,6 +78,17 @@ func (s *Set[T]) Intersection(s2 *Set[T]) *Set[T] {
 	return intersection
 }
 
+// Returns a new set instance containing elements that exists in the first set, but not in the second.
+func (s *Set[T]) Difference(s2 *Set[T]) *Set[T] {
+	difference := NewSet[T]()
+	for key := range s.items {
+		if !s2.Contains(key) {
+			difference.Add(key)
+		}
+	}
+	return difference
+}
+
 // Removes all elements from the set.
 func (s *Set[T]) Clear() {
 	s.items = make(map[T]struct{})

--- a/set_test.go
+++ b/set_test.go
@@ -233,3 +233,106 @@ func TestSetType(t *testing.T) {
 
 	assert.Equal(t, collections.TypeSet, s.Type())
 }
+
+func TestSetUnion(t *testing.T) {
+	testCases := []struct {
+		set1   *collections.Set[int]
+		set2   *collections.Set[int]
+		output *collections.Set[int]
+	}{
+		{
+			set1:   collections.ToSet([]int{1, 2, 3}),
+			set2:   collections.ToSet([]int{4, 5, 6}),
+			output: collections.ToSet([]int{1, 2, 3, 4, 5, 6}),
+		},
+		{
+			set1:   collections.ToSet([]int{1, 2, 3}),
+			set2:   collections.ToSet([]int{3, 4, 5}),
+			output: collections.ToSet([]int{1, 2, 3, 4, 5}),
+		},
+		{
+			set1:   collections.ToSet([]int{}),
+			set2:   collections.ToSet([]int{3, 4, 5}),
+			output: collections.ToSet([]int{3, 4, 5}),
+		},
+		{
+			set1:   collections.ToSet([]int{1, 2}),
+			set2:   collections.ToSet([]int{}),
+			output: collections.ToSet([]int{1, 2}),
+		},
+	}
+
+	for _, tc := range testCases {
+		s := tc.set1.Union(tc.set2)
+		assert.Equal(t, tc.output, s)
+	}
+}
+
+// TODO
+func TestSetIntersection(t *testing.T) {
+	testCases := []struct {
+		set1   *collections.Set[int]
+		set2   *collections.Set[int]
+		output *collections.Set[int]
+	}{
+		{
+			set1:   collections.ToSet([]int{1, 2, 3}),
+			set2:   collections.ToSet([]int{4, 5, 6}),
+			output: collections.ToSet([]int{}),
+		},
+		{
+			set1:   collections.ToSet([]int{4, 1, 2, 3}),
+			set2:   collections.ToSet([]int{3, 4, 5}),
+			output: collections.ToSet([]int{3,4}),
+		},
+		{
+			set1:   collections.ToSet([]int{}),
+			set2:   collections.ToSet([]int{3, 4, 5}),
+			output: collections.ToSet([]int{}),
+		},
+		{
+			set1:   collections.ToSet([]int{1, 2}),
+			set2:   collections.ToSet([]int{}),
+			output: collections.ToSet([]int{}),
+		},
+	}
+
+	for _, tc := range testCases {
+		s := tc.set1.Intersection(tc.set2)
+		assert.Equal(t, tc.output, s)
+	}
+}
+
+func TestSetDifference(t *testing.T) {
+	testCases := []struct {
+		set1   *collections.Set[int]
+		set2   *collections.Set[int]
+		output *collections.Set[int]
+	}{
+		{
+			set1:   collections.ToSet([]int{1, 2, 3}),
+			set2:   collections.ToSet([]int{4, 5, 6}),
+			output: collections.ToSet([]int{1, 2, 3}),
+		},
+		{
+			set1:   collections.ToSet([]int{1, 2, 3}),
+			set2:   collections.ToSet([]int{3, 4, 5}),
+			output: collections.ToSet([]int{1, 2}),
+		},
+		{
+			set1:   collections.ToSet([]int{}),
+			set2:   collections.ToSet([]int{3, 4, 5}),
+			output: collections.ToSet([]int{}),
+		},
+		{
+			set1:   collections.ToSet([]int{1, 2}),
+			set2:   collections.ToSet([]int{}),
+			output: collections.ToSet([]int{1, 2}),
+		},
+	}
+
+	for _, tc := range testCases {
+        s := tc.set1.Difference(tc.set2)
+		assert.Equal(t, tc.output, s)
+	}
+}


### PR DESCRIPTION
### Description

This PR extends the functionality of Set by adding the following methods.

`func (s *Set[T]) Union(s2 *Set[T]) *Set[T]` -> returns a new set as the union of both sets
`func (s *Set[T]) Intersection(s2 *Set[T]) *Set[T]` -> returns a new set with elements that exist in both sets
`func (s *Set[T]) Difference(s2 *Set[T]) *Set[T]` -> returns a new set with the elements that exists in s1 but not in s2

### Related Issues

Closes #30

### Checklist

- [x] I have tested this code.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation.
- [x] This PR follows the coding standards.
- [x] I have added tests for the changes.
